### PR TITLE
Enable on/off tags to retain unusual format

### DIFF
--- a/src/main/resources/eclipse-formatter-config-2space.xml
+++ b/src/main/resources/eclipse-formatter-config-2space.xml
@@ -16,7 +16,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>


### PR DESCRIPTION
I was thinking about a different setting, but changed my mind.
With on/off tags enabled, I should be able to write a multi-line string literal as follows in some tests.

```java
    // @formatter:off
    String script = "--  //  comment\n"
        + "do part\n"
        + "--//@UNDO\n"
        + "first undo part\n"
        + "--//@UNDO\n"
        + "second undo part\n";
    // @formatter:on
```

Please let me know if there is any concern :)