### PR TITLE
Every enum constant on a new line.

### DIFF
--- a/src/main/resources/eclipse-formatter-config-2space.xml
+++ b/src/main/resources/eclipse-formatter-config-2space.xml
@@ -258,7 +258,7 @@
 <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>


### PR DESCRIPTION
With this change, every enum constants will be on a new line.
So, instead of ...

```java
public enum ExecutorType {
  SIMPLE, REUSE, BATCH
}
```

... it will be ...

```java
public enum ExecutorType {
  SIMPLE,
  REUSE,
  BATCH
}
```

This might be a matter of preference, but it provides better readability especially when there are [many constants](https://github.com/mybatis/migrations/blob/759460910b6fc0d8d856ffa57bce47a23b6b97f6/src/main/java/org/apache/ibatis/migration/options/Options.java), IMHO.
Feel free to drop this if you are not sure. =)